### PR TITLE
Fix crashing of user interface when displaying signed messages

### DIFF
--- a/app.py
+++ b/app.py
@@ -313,7 +313,7 @@ def decode_packet(PacketParent, Packet, Filler, FillerChar, PrintSleep=0):
     if (PacketParent.upper() != 'MAINPACKET'):
         Filler = Filler + FillerChar
 
-    Window4.scroll_print("{}".format(PacketParent).upper(), 2)
+    #Window4.scroll_print("{}".format(PacketParent).upper(), 2)
     update_status_window(NewLastPacketType=PacketParent)
 
     # adjust the input to slow down the output for that cool retro feel
@@ -336,17 +336,17 @@ def decode_packet(PacketParent, Packet, Filler, FillerChar, PrintSleep=0):
             if isinstance(Value, collections.abc.Mapping):
 
                 # Print the name/type of the packet
-                Window4.scroll_print(" ", 2)
+                #Window4.scroll_print(" ", 2)
                 LastPacketType = Key.upper()
 
                 decode_packet("{}/{}".format(PacketParent, Key).upper(), Value, Filler, FillerChar, PrintSleep=PrintSleep)
 
-            else:
-                # Print KEY if not RAW (gotta decode those further, or ignore)
-                if (Key == 'raw'):
-                    Window4.scroll_print("{}  RAW value not yet suported by DecodePacket function".format(Filler), 2)
-                else:
-                    Window4.scroll_print("  {}{}: {}".format(Filler, Key, Value), 2)
+            # else:
+            #     # Print KEY if not RAW (gotta decode those further, or ignore)
+            #     if (Key == 'raw'):
+            #         #Window4.scroll_print("{}  RAW value not yet suported by DecodePacket function".format(Filler), 2)
+            #     else:
+            #         #Window4.scroll_print("  {}{}: {}".format(Filler, Key, Value), 2)
 
     else:
         Window2.scroll_print("Warning: Not a packet!", 5, TimeStamp=True)
@@ -360,8 +360,8 @@ def on_receive(packet, interface):
     PacketsReceived = PacketsReceived + 1
 
     Window2.scroll_print("onReceive", 2, TimeStamp=True)
-    Window4.scroll_print(" ", 2)
-    Window4.scroll_print("==Packet RECEIVED======================================", 2)
+    #Window4.scroll_print(" ", 2)
+    #Window4.scroll_print("==Packet RECEIVED======================================", 2)
 
     decoded = packet.get('decoded')
     unsigned_message = decoded.get('text')
@@ -390,8 +390,8 @@ def on_receive(packet, interface):
         except BadSignatureError:
             Window3.scroll_print("Signature from {} was forged or corrupt".format(sender), 2, TimeStamp=True)
 
-    Window4.scroll_print("=======================================================", 2)
-    Window4.scroll_print(" ", 2)
+    #Window4.scroll_print("=======================================================", 2)
+    #Window4.scroll_print(" ", 2)
 
 
 # called when we (re)connect to the radio
@@ -411,15 +411,13 @@ def on_connection_established(interface, topic=pub.AUTO_TOPIC):
 
         try:
             interface.sendText(Message, wantAck=True)
-            Window4.scroll_print("", 2)
-            Window4.scroll_print(
-                "==Packet SENT==========================================", 3)
-            Window4.scroll_print("To:     {}:".format(To), 3)
-            Window4.scroll_print("From    {}:".format(From), 3)
-            Window4.scroll_print("Message {}:".format(Message), 3)
-            Window4.scroll_print(
-                "=======================================================", 3)
-            Window4.scroll_print("", 2)
+            #Window4.scroll_print("", 2)
+            #Window4.scroll_print("==Packet SENT==========================================", 3)
+            #Window4.scroll_print("To:     {}:".format(To), 3)
+            #Window4.scroll_print("From    {}:".format(From), 3)
+            #Window4.scroll_print("Message {}:".format(Message), 3)
+            #Window4.scroll_print("=======================================================", 3)
+            #Window4.scroll_print("", 2)
 
         except Exception as ErrorMessage:
             TraceMessage = traceback.format_exc()
@@ -441,7 +439,7 @@ def on_node_update(interface, topic=pub.AUTO_TOPIC):
     if (PriorityOutput == False):
         Window2.scroll_print('onNodeUpdated', 2, TimeStamp=True)
         Window1.window_print(1, 4, 'UPDATE RECEIVED', 1, TimeStamp=True)
-        Window4.scroll_print("", 2)
+        #Window4.scroll_print("", 2)
 
 
 def sigint_handler(signal_received, frame):
@@ -650,15 +648,13 @@ def send_unsigned_message(interface, Message=''):
     # Send the message to the device
     interface.sendText(TheMessage, wantAck=True)
 
-    Window4.scroll_print(" ", 2)
-    Window4.scroll_print(
-        "==Unsigned Packet SENT=================================", 3)
-    Window4.scroll_print("To:      All:", 3)
-    Window4.scroll_print("From:    BaseStation", 3)
-    Window4.scroll_print("Message: {}".format(TheMessage), 3)
-    Window4.scroll_print(
-        "=======================================================", 3)
-    Window4.scroll_print(" ", 2)
+    #Window4.scroll_print(" ", 2)
+    #Window4.scroll_print("==Unsigned Packet SENT=================================", 3)
+    #Window4.scroll_print("To:      All:", 3)
+    #Window4.scroll_print("From:    BaseStation", 3)
+    #Window4.scroll_print("Message: {}".format(TheMessage), 3)
+    #Window4.scroll_print("=======================================================", 3)
+    #Window4.scroll_print(" ", 2)
 
     SendMessageWindow.clear()
     SendMessageWindow.TitleColor = 2
@@ -718,13 +714,13 @@ def send_signed_message(interface, Message=''):
 
     interface.sendSignedText(signed_message_bytes, wantAck=True)
 
-    Window4.scroll_print(" ", 2)
-    Window4.scroll_print("==Signed Packet SENT===================================", 3)
-    Window4.scroll_print("To:      All:", 3)
-    Window4.scroll_print("From:    BaseStation", 3)
-    Window4.scroll_print("Message: {}".format(TheMessage), 3)
-    Window4.scroll_print("=======================================================", 3)
-    Window4.scroll_print(" ", 2)
+    #Window4.scroll_print(" ", 2)
+    #Window4.scroll_print("==Signed Packet SENT===================================", 3)
+    #Window4.scroll_print("To:      All:", 3)
+    #Window4.scroll_print("From:    BaseStation", 3)
+    #Window4.scroll_print("Message: {}".format(TheMessage), 3)
+    #Window4.scroll_print("=======================================================", 3)
+    #Window4.scroll_print(" ", 2)
 
     SendMessageWindow.clear()
     SendMessageWindow.TitleColor = 2

--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ from sys import exit
 # PyNaCl libsodium library
 from nacl_suite import NaclSuite
 
-from nacl.encoding import Base64Encoder
+from nacl.encoding import HexEncoder
 from nacl.signing import VerifyKey
 from nacl.exceptions import BadSignatureError
 
@@ -381,11 +381,11 @@ def on_receive(packet, interface):
         verify_key_b64 = signed_message[-64:]
 
         # Create a VerifyKey object from a base64 serialized public key
-        verify_key = VerifyKey(verify_key_b64, encoder=Base64Encoder)
+        verify_key = VerifyKey(verify_key_b64, encoder=HexEncoder)
 
         # Check the validity of a message's signature
         try:
-            text_message_bytes = verify_key.verify(signed_b64, encoder=Base64Encoder)
+            text_message_bytes = verify_key.verify(signed_b64, encoder=HexEncoder)
             text_message = text_message_bytes.decode('utf-8')
             Window3.scroll_print("VERIFIED SIGNED message from: {} - {}".format(sender, text_message), 2, TimeStamp=True)
         except BadSignatureError:
@@ -703,13 +703,13 @@ def send_signed_message(interface, Message=''):
     text_message_bytes = TheMessage.encode('utf-8')
 
     # Sign a message with the signing key
-    signed_b64 = signing_key.sign(text_message_bytes, encoder=Base64Encoder)
+    signed_b64 = signing_key.sign(text_message_bytes, encoder=HexEncoder)
 
     # Obtain the verify key for a given signing key
     verify_key = signing_key.verify_key
 
     # Serialize the verify key to send it to a third party
-    verify_key_b64 = verify_key.encode(encoder=Base64Encoder)
+    verify_key_b64 = verify_key.encode(encoder=HexEncoder)
 
     signed_message_bytes = signed_b64 + verify_key_b64
 

--- a/app.py
+++ b/app.py
@@ -34,7 +34,7 @@ from sys import exit
 # PyNaCl libsodium library
 from nacl_suite import NaclSuite
 
-from nacl.encoding import HexEncoder
+from nacl.encoding import Base64Encoder
 from nacl.signing import VerifyKey
 from nacl.exceptions import BadSignatureError
 
@@ -381,11 +381,11 @@ def on_receive(packet, interface):
         verify_key_b64 = signed_message[-64:]
 
         # Create a VerifyKey object from a base64 serialized public key
-        verify_key = VerifyKey(verify_key_b64, encoder=HexEncoder)
+        verify_key = VerifyKey(verify_key_b64, encoder=Base64Encoder)
 
         # Check the validity of a message's signature
         try:
-            text_message_bytes = verify_key.verify(signed_b64, encoder=HexEncoder)
+            text_message_bytes = verify_key.verify(signed_b64, encoder=Base64Encoder)
             text_message = text_message_bytes.decode('utf-8')
             Window3.scroll_print("VERIFIED SIGNED message from: {} - {}".format(sender, text_message), 2, TimeStamp=True)
         except BadSignatureError:
@@ -703,13 +703,13 @@ def send_signed_message(interface, Message=''):
     text_message_bytes = TheMessage.encode('utf-8')
 
     # Sign a message with the signing key
-    signed_b64 = signing_key.sign(text_message_bytes, encoder=HexEncoder)
+    signed_b64 = signing_key.sign(text_message_bytes, encoder=Base64Encoder)
 
     # Obtain the verify key for a given signing key
     verify_key = signing_key.verify_key
 
     # Serialize the verify key to send it to a third party
-    verify_key_b64 = verify_key.encode(encoder=HexEncoder)
+    verify_key_b64 = verify_key.encode(encoder=Base64Encoder)
 
     signed_message_bytes = signed_b64 + verify_key_b64
 

--- a/app.py
+++ b/app.py
@@ -373,7 +373,7 @@ def on_receive(packet, interface):
     decode_packet('MainPacket', packet, Filler='', FillerChar='', PrintSleep=PrintSleep)
 
     if unsigned_message:
-        Window3.scroll_print("UNSIGNED message from: {} - {}".format(portnum, unsigned_message), 2, TimeStamp=True)
+        Window3.scroll_print("UNSIGNED message from: {} - {}".format(sender, unsigned_message), 2, TimeStamp=True)
     elif portnum == "BLACK_LAGER":
         signed_message = decoded.get('payload')
         # Split the concatenated byte string into the message and key

--- a/app.py
+++ b/app.py
@@ -365,7 +365,7 @@ def on_receive(packet, interface):
 
     decoded = packet.get('decoded')
     unsigned_message = decoded.get('text')
-    signed_message = decoded.get('signed-text')
+    portnum = decoded.get('portnum')
 
     sender = packet.get('from')
 
@@ -373,8 +373,9 @@ def on_receive(packet, interface):
     decode_packet('MainPacket', packet, Filler='', FillerChar='', PrintSleep=PrintSleep)
 
     if unsigned_message:
-        Window3.scroll_print("UNSIGNED message from: {} - {}".format(sender, unsigned_message), 2, TimeStamp=True)
-    elif signed_message:
+        Window3.scroll_print("UNSIGNED message from: {} - {}".format(portnum, unsigned_message), 2, TimeStamp=True)
+    elif portnum == "BLACK_LAGER":
+        signed_message = decoded.get('payload')
         # Split the concatenated byte string into the message and key
         signed_b64 = signed_message[:-64]
         verify_key_b64 = signed_message[-64:]
@@ -666,7 +667,7 @@ def send_unsigned_message(interface, Message=''):
 
 
 def send_signed_message(interface, Message=''):
-    Window2.scroll_print("SendSignedMessagePacket", 2)
+    #Window2.scroll_print("SendSignedMessagePacket", 2)
     TheMessage = ''
 
     InputMessageWindow.TextWindow.move(0, 0)


### PR DESCRIPTION
Close #26

Fixed bug by not displaying the raw bytes of the signed message and only showing the decoded message.